### PR TITLE
Resolve dependency doesn't exist issue

### DIFF
--- a/breeze/pom.xml
+++ b/breeze/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>zktheme</artifactId>
 		<groupId>org.zkoss.theme</groupId>
-		<version>9.0.1-SNAPSHOT</version>
+		<version>9.0.0</version>
 	</parent>
 	<artifactId>breeze</artifactId>
 	<packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.zkoss.theme</groupId>
 	<artifactId>zktheme</artifactId>
-	<version>9.0.1-SNAPSHOT</version>
+	<version>9.0.0</version>
 	<packaging>pom</packaging>
 	<name>ZK Theme Maven Bulider</name>
 	<url>http://www.zkoss.org/themes</url>
@@ -73,12 +73,13 @@
 			<version>${project.version}</version>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
+		<!-- Commenting, as version 9.0.1-SNAPSHOT doesn't yet exist in ZK maven repo -->
+		<!-- <dependency>
 			<groupId>org.zkoss.zk</groupId>
 			<artifactId>zkmax</artifactId>
 			<version>${project.version}</version>
 			<optional>true</optional>
-		</dependency>
+		</dependency> -->
 	</dependencies>
 	<build>
 		<sourceDirectory>${project.basedir}/src/</sourceDirectory>

--- a/sapphire/pom.xml
+++ b/sapphire/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.zkoss.theme</groupId>
 		<artifactId>zktheme</artifactId>
-		<version>9.0.1-SNAPSHOT</version>
+		<version>9.0.0</version>
 	</parent>
 	<artifactId>sapphire</artifactId>
 	<packaging>jar</packaging>

--- a/silvertail/pom.xml
+++ b/silvertail/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.zkoss.theme</groupId>
 		<artifactId>zktheme</artifactId>
-		<version>9.0.1-SNAPSHOT</version>
+		<version>9.0.0</version>
 	</parent>
 	<artifactId>silvertail</artifactId>
 	<packaging>jar</packaging>


### PR DESCRIPTION
Commit 1792e54 "upgrade to ZK 9.0.1 version" broke the `mvn clean package` command, as 9.0.1-SNAPSHOT is not available in ZK maven repo.

